### PR TITLE
chore: autonomi rebranding

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,9 +10,9 @@ on: pull_request
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: "-D warnings"
-  CLIENT_VERSION: 0.1.2
-  NODE_VERSION: 0.112.1
-  NODE_MANAGER_VERSION: 0.11.0
+  CLIENT_VERSION: 0.3.0-rc.1
+  NODE_VERSION: 0.3.0-rc.1
+  ANTCTL_VERSION: 0.11.4-rc.1
 
 jobs:
   # The code in this crate uses lots of conditional compilation for cross-platform capabilities.
@@ -142,20 +142,20 @@ jobs:
         run: |
           cargo run -- client --version $env:CLIENT_VERSION
           cargo run -- node --version $env:NODE_VERSION
-          cargo run -- node-manager --version $env:NODE_MANAGER_VERSION
+          cargo run -- antctl --version $env:ANTCTL_VERSION
       - name: Check if binaries are available in new shell session
         shell: pwsh
         run: |
-          if (!(Test-Path "$env:USERPROFILE\autonomi\autonomi.exe")) {
-            Write-Host "autonomi.exe does not exist"
+          if (!(Test-Path "$env:USERPROFILE\autonomi\ant.exe")) {
+            Write-Host "ant.exe does not exist"
             exit 1
           }
-          if (!(Test-Path "$env:USERPROFILE\autonomi\safenode.exe")) {
-            Write-Host "safenode.exe does not exist"
+          if (!(Test-Path "$env:USERPROFILE\autonomi\antnode.exe")) {
+            Write-Host "antnode.exe does not exist"
             exit 1
           }
-          if (!(Test-Path "$env:USERPROFILE\autonomi\safenode-manager.exe")) {
-            Write-Host "safenode-manager.exe does not exist"
+          if (!(Test-Path "$env:USERPROFILE\autonomi\antctl.exe")) {
+            Write-Host "antctl.exe does not exist"
             exit 1
           }
 
@@ -163,8 +163,8 @@ jobs:
           # being modified easily, so we need to refer to the binaries with their full paths.
           # Other manual testing has proven that the changes to the Path environment variable do
           # take effect.
-          $output = & "${env:USERPROFILE}\autonomi\autonomi.exe" --version
-          $version = $output | Select-String -Pattern "autonomi-cli (\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[0-9]+)?)?)"
+          $output = & "${env:USERPROFILE}\autonomi\ant.exe" --version
+          $version = $output | Select-String -Pattern "ant-cli (\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[0-9]+)?)?)"
           $versionNumber = $version.Matches.Groups[1].Value
           if ($versionNumber -eq "$env:CLIENT_VERSION") {
             Write-Host "The correct version of autonomi has been installed"
@@ -175,26 +175,26 @@ jobs:
             exit 1
           }
 
-          $output = & "${env:USERPROFILE}\autonomi\safenode.exe" --version
+          $output = & "${env:USERPROFILE}\autonomi\antnode.exe" --version
           $version = $output -split "`n" | Select-Object -First 1
           $versionNumber = ($version -split "v")[1].Trim()
           if ($versionNumber -eq "$env:NODE_VERSION") {
-            Write-Host "The correct version of safenode has been installed"
+            Write-Host "The correct version of antnode has been installed"
           } else {
-            Write-Host "The correct version of safenode has not been installed"
+            Write-Host "The correct version of antnode has not been installed"
             Write-Host "We expected version $env:NODE_VERSION"
             Write-Host "The downloaded binary has $versionNumber"
             exit 1
           }
 
-          $output = & "${env:USERPROFILE}\autonomi\safenode-manager.exe" --version
+          $output = & "${env:USERPROFILE}\autonomi\antctl.exe" --version
           $version = $output -split "`n" | Select-Object -First 1
           $versionNumber = ($version -split "v")[1].Trim()
-          if ($versionNumber -eq "$env:NODE_MANAGER_VERSION") {
-            Write-Host "The correct version of safenode-manager has been installed"
+          if ($versionNumber -eq "$env:ANTCTL_VERSION") {
+            Write-Host "The correct version of antctl has been installed"
           } else {
-            Write-Host "The correct version of safenode-manager has not been installed"
-            Write-Host "We expected version $env:NODE_MANAGER_VERSION"
+            Write-Host "The correct version of antctl has not been installed"
+            Write-Host "We expected version $env:ANTCTL_VERSION"
             Write-Host "The downloaded binary has $versionNumber"
             exit 1
           }
@@ -215,7 +215,7 @@ jobs:
         run: |
           cargo run -- client --version $CLIENT_VERSION
           cargo run -- node --version $NODE_VERSION
-          cargo run -- node-manager --version $NODE_MANAGER_VERSION
+          cargo run -- antctl --version $ANTCTL_VERSION
       - name: Check if binaries are available in new shell session
         shell: bash
         run: |
@@ -228,36 +228,36 @@ jobs:
           # locations.
           source ~/.config/autonomi/env
 
-          [[ -f "$HOME/.local/bin/autonomi" ]] || { echo "autonomi not in expected location"; exit 1; }
-          [[ -f "$HOME/.local/bin/safenode" ]] || { echo "safenode not in expected location"; exit 1; }
-          [[ -f "$HOME/.local/bin/safenode-manager" ]] || { echo "safenode-manager not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/ant" ]] || { echo "ant not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/antnode" ]] || { echo "antnode not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/antctl" ]] || { echo "antctl not in expected location"; exit 1; }
 
-          version=$(autonomi --version | awk '{ print $2 }')
+          version=$(ant --version | awk '{ print $2 }')
           if [[ "$version" == "$CLIENT_VERSION" ]]; then
-            echo "The correct version of autonomi has been installed"
+            echo "The correct version of ant has been installed"
           else
-            echo "The correct version of autonomi has not been installed"
+            echo "The correct version of ant has not been installed"
             echo "We expected $CLIENT_VERSION"
             echo "The downloaded binary has $version"
             exit 1
           fi
 
-          version=$(safenode --version | head -n 1 | awk '{print $3}' | sed 's/^v//')
+          version=$(antnode --version | head -n 1 | awk '{print $3}' | sed 's/^v//')
           if [[ "$version" == "$NODE_VERSION" ]]; then
-            echo "The correct version of safenode has been installed"
+            echo "The correct version of antnode has been installed"
           else
-            echo "The correct version of safenode has not been installed"
+            echo "The correct version of antnode has not been installed"
             echo "We expected $NODE_VERSION"
             echo "The downloaded binary has $version"
             exit 1
           fi
 
-          version=$(safenode-manager --version | head -n 1 | awk '{print $4}' | sed 's/^v//')
-          if [[ "$version" == "$NODE_MANAGER_VERSION" ]]; then
-            echo "The correct version of safenode-manager has been installed"
+          version=$(antctl --version | head -n 1 | awk '{print $4}' | sed 's/^v//')
+          if [[ "$version" == "$ANTCTL_VERSION" ]]; then
+            echo "The correct version of antctl has been installed"
           else
-            echo "The correct version of safenode-manager has not been installed"
-            echo "We expected $NODE_MANAGER_VERSION"
+            echo "The correct version of antctl has not been installed"
+            echo "We expected $ANTCTL_VERSION"
             echo "The downloaded binary has $version"
             exit 1
           fi
@@ -277,42 +277,42 @@ jobs:
         run: |
           cargo run -- client --version $CLIENT_VERSION
           cargo run -- node --version $NODE_VERSION
-          cargo run -- node-manager --version $NODE_MANAGER_VERSION
+          cargo run -- antctl --version $ANTCTL_VERSION
       - name: Check if binaries are available in new shell session
         run: |
           # As with the Ubuntu test, we need to source the env file to get the binaries on PATH.
           source "/Users/runner/Library/Application Support/autonomi/env"
 
-          [[ -f "$HOME/.local/bin/autonomi" ]] || { echo "autonomi not in expected location"; exit 1; }
-          [[ -f "$HOME/.local/bin/safenode" ]] || { echo "safenode not in expected location"; exit 1; }
-          [[ -f "$HOME/.local/bin/safenode-manager" ]] || { echo "safenode-manager not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/ant" ]] || { echo "ant not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/antnode" ]] || { echo "antnode not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/antctl" ]] || { echo "antctl not in expected location"; exit 1; }
 
-          version=$(autonomi --version | awk '{ print $2 }')
+          version=$(ant --version | awk '{ print $2 }')
           if [[ "$version" == "$CLIENT_VERSION" ]]; then
-            echo "The correct version of autonomi has been installed"
+            echo "The correct version of ant has been installed"
           else
-            echo "The correct version of autonomi has not been installed"
+            echo "The correct version of ant has not been installed"
             echo "We expected $CLIENT_VERSION"
             echo "The downloaded binary has $version"
             exit 1
           fi
 
-          version=$(safenode --version | head -n 1 | awk '{print $3}' | sed 's/^v//')
+          version=$(antnode --version | head -n 1 | awk '{print $3}' | sed 's/^v//')
           if [[ "$version" == "$NODE_VERSION" ]]; then
-            echo "The correct version of safenode has been installed"
+            echo "The correct version of antnode has been installed"
           else
-            echo "The correct version of safenode has not been installed"
+            echo "The correct version of antnode has not been installed"
             echo "We expected $NODE_VERSION"
             echo "The downloaded binary has $version"
             exit 1
           fi
 
-          version=$(safenode-manager --version | head -n 1 | awk '{print $4}' | sed 's/^v//')
-          if [[ "$version" == "$NODE_MANAGER_VERSION" ]]; then
-            echo "The correct version of safenode-manager has been installed"
+          version=$(antctl --version | head -n 1 | awk '{print $4}' | sed 's/^v//')
+          if [[ "$version" == "$ANTCTL_VERSION" ]]; then
+            echo "The correct version of antctl has been installed"
           else
-            echo "The correct version of safenode-manager has not been installed"
-            echo "We expected $NODE_MANAGER_VERSION"
+            echo "The correct version of antctl has not been installed"
+            echo "We expected $ANTCTL_VERSION"
             echo "The downloaded binary has $version"
             exit 1
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
-name = "safeup"
+name = "antup"
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
-description = "CLI for installing components for accessing the Safe Network"
+description = "CLI for installing components for accessing the Autonomi network"
 license = "GPL-3.0"
 version = "0.8.1"
 edition = "2021"
 
 [[bin]]
-name = "safeup"
+name = "antup"
 path = "src/main.rs"
 
 [dependencies]
+ant-releases = "0.4.0"
 clap = { version = "4.1.6", features = ["derive"] }
 chrono = "0.4.26"
 color-eyre = "0.6.2"
@@ -24,7 +25,6 @@ semver = "1.0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-sn-releases = "0.3.1"
 tempfile = "3.8.1"
 textwrap = "0.16.0"
 tokio = { version = "1.26", features = ["full"] }

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env just --justfile
 
-release_repo := "maidsafe/safeup"
+release_repo := "maidsafe/antup"
 
 build-release-artifacts arch:
   #!/usr/bin/env bash
@@ -48,9 +48,9 @@ build-release-artifacts arch:
   cargo clean
   if [[ $arch == arm* || $arch == armv7* || $arch == aarch64* ]]; then
     cargo install cross
-    cross build --release --target $arch --bin safeup
+    cross build --release --target $arch --bin antup
   else
-    cargo build --release --target $arch --bin safeup
+    cargo build --release --target $arch --bin antup
   fi
 
   find target/$arch/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
@@ -69,7 +69,7 @@ package-release-assets:
     "armv7-unknown-linux-musleabihf"
     "aarch64-unknown-linux-musl"
   )
-  bin="safeup"
+  bin="antup"
   version=$(cat Cargo.toml | grep "^version" | awk -F '=' '{ print $2 }' | xargs)
 
   rm -rf deploy/$bin
@@ -90,14 +90,14 @@ upload-release-assets:
   set -e
   version=$(cat Cargo.toml | grep "^version" | awk -F '=' '{ print $2 }' | xargs)
   echo "Uploading assets to release..."
-  cd deploy/safeup
+  cd deploy/antup
   ls | xargs gh release upload "v${version}" --repo {{release_repo}}
 
 upload-release-assets-to-s3:
   #!/usr/bin/env bash
   set -e
 
-  cd deploy/safeup
+  cd deploy/antup
   for file in *.zip *.tar.gz; do
-    aws s3 cp "$file" "s3://sn-safeup/$file" --acl public-read
+    aws s3 cp "$file" "s3://antup/$file" --acl public-read
   done

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# safeup
+# antup
 
 Simple utility for installing and updating safe-related components.
 
@@ -6,48 +6,48 @@ Simple utility for installing and updating safe-related components.
 
 ### Linux/macOS
 
-You can choose to run the installation for `safeup` as the current user or with `sudo`. The difference between them is the install location and modification of the shell profile. If running with `sudo`, `safeup` will be installed to `/usr/local/bin`; otherwise it will be installed to `~/.local/bin` and the Bash shell profile will be modified to add that location to the `PATH` variable. For almost any Linux-based or macOS installation, `/usr/local/bin` is already available on `PATH` as standard.
+You can choose to run the installation for `antup` as the current user or with `sudo`. The difference between them is the install location and modification of the shell profile. If running with `sudo`, `antup` will be installed to `/usr/local/bin`; otherwise it will be installed to `~/.local/bin` and the Bash shell profile will be modified to add that location to the `PATH` variable. For almost any Linux-based or macOS installation, `/usr/local/bin` is already available on `PATH` as standard.
 
 To install as `sudo`, use the following:
 ```
-curl -sSL https://raw.githubusercontent.com/maidsafe/safeup/main/install.sh | sudo bash
+curl -sSL https://raw.githubusercontent.com/maidsafe/antup/main/install.sh | sudo bash
 ```
 
 Otherwise:
 ```
-curl -sSL https://raw.githubusercontent.com/maidsafe/safeup/main/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/maidsafe/antup/main/install.sh | bash
 ```
 
-This process will download and install `safeup` for your platform.
+This process will download and install `antup` for your platform.
 
-The install script also accepts two flag arguments, namely `--client` and `--node`. If either are used, the script will invoke the installed `safeup` binary to install `autonomi` and `safenode`, respectively, without having to run either as an additional post-install step.
+The install script also accepts two flag arguments, namely `--client` and `--node`. If either are used, the script will invoke the installed `antup` binary to install `autonomi` and `safenode`, respectively, without having to run either as an additional post-install step.
 
 To use these options as `sudo`:
 ```
-curl -sSL https://raw.githubusercontent.com/maidsafe/safeup/main/install.sh | sudo bash -s -- --client
+curl -sSL https://raw.githubusercontent.com/maidsafe/antup/main/install.sh | sudo bash -s -- --client
 ```
 
 Otherwise:
 ```
-curl -sSL https://raw.githubusercontent.com/maidsafe/safeup/main/install.sh | bash -s -- --client
+curl -sSL https://raw.githubusercontent.com/maidsafe/antup/main/install.sh | bash -s -- --client
 ```
 
 ### Windows
 
-On Windows, we are currently not supporting installing either `safeup` or the other binaries with Administrator privileges, so there is only one command:
+On Windows, we are currently not supporting installing either `antup` or the other binaries with Administrator privileges, so there is only one command:
 ```
-iex (Invoke-RestMethod -Uri "https://raw.githubusercontent.com/maidsafe/safeup/main/install.ps1")
+iex (Invoke-RestMethod -Uri "https://raw.githubusercontent.com/maidsafe/antup/main/install.ps1")
 ```
 
 The Powershell installer does not support the `--client` or `--node` arguments because it's not possible to pass them when the script is downloaded.
 
-Therefore, installing any components on Windows is an additional post-safeup-installation step.
+Therefore, installing any components on Windows is an additional post-installation step.
 
 ## Usage
 
-Use the `client`, `node` or `testnet` commands to install the latest versions of the `autonomi`, `safenode` or `testnet` binaries, respectively. 
+Use the `client`, `node` or `antctl` commands to install the latest versions of the `ant`, `antnode` or `antctl` binaries, respectively. 
 
-As above, you can choose to run `safeup` using `sudo`, depending on where you'd like your binaries installed. Again, this does not apply to Windows, where we don't support running with Administrator privileges.
+As above, you can choose to run `antup` using `sudo`, depending on where you'd like your binaries installed. Again, this does not apply to Windows, where we don't support running with Administrator privileges.
 
 ## License
 

--- a/install.ps1
+++ b/install.ps1
@@ -2,36 +2,36 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "**************************************"
 Write-Host "*                                    *"
-Write-Host "*         Installing safeup          *"
+Write-Host "*         Installing antup           *"
 Write-Host "*                                    *"
 Write-Host "**************************************"
 
 $response = Invoke-WebRequest `
-    -Uri "https://api.github.com/repos/maidsafe/safeup/releases/latest" `
+    -Uri "https://api.github.com/repos/maidsafe/antup/releases/latest" `
     -UseBasicParsing
 $json = $response | ConvertFrom-Json
 $version = $json.tag_name.TrimStart('v')
-Write-Host "Latest version of safeup is $version"
-$asset = $json.assets | Where-Object { $_.name -match "safeup-$version-x86_64-pc-windows-msvc.zip" }
+Write-Host "Latest version of antup is $version"
+$asset = $json.assets | Where-Object { $_.name -match "antup-$version-x86_64-pc-windows-msvc.zip" }
 $downloadUrl = $asset.browser_download_url
 
-$archivePath = Join-Path $env:TEMP "safeup.zip"
+$archivePath = Join-Path $env:TEMP "antup.zip"
 Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath
 
-$autonomiPath = Join-Path $env:USERPROFILE "autonomi"
-New-Item -ItemType Directory -Force -Path $autonomiPath
-Expand-Archive -Path $archivePath -DestinationPath $autonomiPath -Force
+$antPath = Join-Path $env:USERPROFILE "ant"
+New-Item -ItemType Directory -Force -Path $antPath
+Expand-Archive -Path $archivePath -DestinationPath $antPath -Force
 Remove-Item $archivePath
-$safeupExePath = Join-Path $autonomiPath "safeup.exe"
+$antExePath = Join-Path $antPath "ant.exe"
 
 $currentPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::User)
-if ($currentPath -notlike "*$autonomiPath*") {
-    $newPath = $currentPath + ";" + $autonomiPath
+if ($currentPath -notlike "*$antPath*") {
+    $newPath = $currentPath + ";" + $antPath
     [Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::User)
-    Write-Host "Added $autonomiPath to user PATH"
+    Write-Host "Added $antPath to user PATH"
 } else {
-    Write-Host "Path $autonomiPath is already in user PATH"
+    Write-Host "Path $antPath is already in user PATH"
 }
 
-Write-Host "You may need to start a new session for safeup to become available."
-Write-Host "When safeup is available, please run 'safeup --help' to see how to install network components."
+Write-Host "You may need to start a new session for antup to become available."
+Write-Host "When antup is available, please run 'antup --help' to see how to install network components."

--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ fi
 function print_banner() {
   echo "**************************************"
   echo "*                                    *"
-  echo "*         Installing safeup          *"
+  echo "*         Installing antup           *"
   echo "*                                    *"
   echo "**************************************"
 }
@@ -73,20 +73,20 @@ function detect_arch() {
     armv7*) arch_triple="armv7-unknown-$os-musleabihf" ;;
     *) echo "Architecture $arch not supported"; exit 1 ;;
   esac
-  echo "Will retrieve safeup for $arch_triple architecture"
+  echo "Will retrieve antup for $arch_triple architecture"
 }
 
 function get_latest_version() {
-  release_data=$(curl --silent "https://api.github.com/repos/maidsafe/safeup/releases/latest")
+  release_data=$(curl --silent "https://api.github.com/repos/maidsafe/antup/releases/latest")
   version=$(echo "$release_data" | awk -F': ' '/"tag_name":/ {print $2}' | \
     sed 's/"//g' | sed 's/,//g' | sed 's/v//g')
   download_url=$(echo "$release_data" | \
     awk -F': ' '/"browser_download_url":/ {print $2 $3}' | \
-    grep "safeup-$version-$arch_triple.tar.gz" | sed 's/"//g' | sed 's/,//g')
-  echo "Latest version of safeup is $version"
+    grep "antup-$version-$arch_triple.tar.gz" | sed 's/"//g' | sed 's/,//g')
+  echo "Latest version of antup is $version"
 }
 
-function install_safeup() {
+function install_antup() {
   if [[ $running_as_root -eq 1 ]]; then
     target_dir="/usr/local/bin"
   else
@@ -107,30 +107,30 @@ EOF
   fi
 
   temp_dir=$(mktemp -d)
-  curl -L "$download_url" -o "$temp_dir/safeup.tar.gz"
-  tar -xzf "$temp_dir/safeup.tar.gz" -C "$temp_dir"
-  mv "$temp_dir/safeup" "$target_dir/safeup"
-  chmod +x "$target_dir/safeup"
+  curl -L "$download_url" -o "$temp_dir/antup.tar.gz"
+  tar -xzf "$temp_dir/antup.tar.gz" -C "$temp_dir"
+  mv "$temp_dir/antup" "$target_dir/antup"
+  chmod +x "$target_dir/antup"
   rm -rf "$temp_dir"
-  echo "safeup installed to $target_dir/safeup"
+  echo "antup installed to $target_dir/antup"
 }
 
 function post_install() {
   if [[ $install_client -eq 1 ]]; then
-    echo "Now running safeup to install the safe client..."
-    $target_dir/safeup client
+    echo "Now running antup to install the safe client..."
+    $target_dir/antup client
   fi
   if [[ $install_node -eq 1 ]]; then
-    echo "Now running safeup to install safenode..."
-    $target_dir/safeup node
+    echo "Now running antup to install safenode..."
+    $target_dir/antup node
   fi
   if [[ $running_as_root -eq 1 ]]; then
-    echo "Please run 'safeup --help' to see how to install network components."
+    echo "Please run 'antup --help' to see how to install network components."
   else
     printf "\n"
-    echo "The safeup binary has been installed, but it's not available in this session."
+    echo "The antup binary has been installed, but it's not available in this session."
     echo "You must either run 'source ~/.config/autonomi/env' in this session, or start a new session."
-    echo "When safeup is available, please run 'safeup --help' to see how to install network components."
+    echo "When antup is available, please run 'antup --help' to see how to install network components."
   fi
 }
 
@@ -138,5 +138,5 @@ print_banner
 detect_os
 detect_arch
 get_latest_version
-install_safeup
+install_antup
 post_install

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -8,11 +8,11 @@
 
 use crate::install::{AssetType, Settings};
 use crate::update::{perform_update_assessment, UpdateAssessmentResult};
+use ant_releases::AntReleaseRepoActions;
 use color_eyre::{eyre::eyre, Result};
 use lazy_static::lazy_static;
 use prettytable::{Cell, Row, Table};
 use semver::Version;
-use sn_releases::SafeReleaseRepoActions;
 use std::collections::HashMap;
 use std::env::consts::{ARCH, OS};
 use std::path::PathBuf;
@@ -28,11 +28,11 @@ lazy_static! {
         );
         m.insert(
             AssetType::Node,
-            "https://sn-node.s3.eu-west-2.amazonaws.com",
+            "https://antnode.s3.eu-west-2.amazonaws.com",
         );
         m.insert(
-            AssetType::NodeManager,
-            "https://sn-node-manager.s3.eu-west-2.amazonaws.com",
+            AssetType::AntCtl,
+            "https://antctl.s3.eu-west-2.amazonaws.com",
         );
         m
     };
@@ -74,7 +74,7 @@ pub(crate) async fn process_update_cmd() -> Result<()> {
     let autonomi_config_dir_path = get_autonomi_config_dir_path()?;
     let settings_file_path = autonomi_config_dir_path.join("safeup.json");
     let settings = Settings::read(&settings_file_path)?;
-    let release_repo = <dyn SafeReleaseRepoActions>::default_config();
+    let release_repo = <dyn AntReleaseRepoActions>::default_config();
 
     for asset_type in AssetType::variants() {
         println!("Retrieving latest version for {asset_type}...");
@@ -151,7 +151,7 @@ async fn do_install_binary(
     version: Option<Version>,
 ) -> Result<()> {
     let platform = get_platform()?;
-    let release_repo = <dyn SafeReleaseRepoActions>::default_config();
+    let release_repo = <dyn AntReleaseRepoActions>::default_config();
     let (installed_version, bin_path) = crate::install::install_bin(
         asset_type.clone(),
         release_repo,
@@ -166,16 +166,16 @@ async fn do_install_binary(
     let mut settings = Settings::read(&settings_file_path)?;
     match asset_type {
         AssetType::Client => {
-            settings.autonomi_path = Some(bin_path);
-            settings.autonomi_version = Some(installed_version);
+            settings.ant_path = Some(bin_path);
+            settings.ant_version = Some(installed_version);
         }
         AssetType::Node => {
-            settings.safenode_path = Some(bin_path);
-            settings.safenode_version = Some(installed_version);
+            settings.antnode_path = Some(bin_path);
+            settings.antnode_version = Some(installed_version);
         }
-        AssetType::NodeManager => {
-            settings.safenode_manager_path = Some(bin_path);
-            settings.safenode_manager_version = Some(installed_version);
+        AssetType::AntCtl => {
+            settings.antctl_path = Some(bin_path);
+            settings.antctl_version = Some(installed_version);
         }
     }
     settings.save(&settings_file_path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Install the autonomi client binary.
+    /// Install the ant client binary.
     ///
     /// The location is platform specific:
     /// - Linux/macOS: $HOME/.local/bin
@@ -53,7 +53,7 @@ enum Commands {
         #[arg(short = 'v', long)]
         version: Option<String>,
     },
-    /// Install the safenode binary.
+    /// Install the antnode binary.
     ///
     /// The location is platform specific:
     /// - Linux/macOS: $HOME/.local/bin
@@ -77,7 +77,7 @@ enum Commands {
         #[arg(short = 'v', long)]
         version: Option<String>,
     },
-    /// Install the safenode-manager binary.
+    /// Install the antctl binary.
     ///
     /// The location is platform specific:
     /// - Linux/macOS: $HOME/.local/bin
@@ -85,8 +85,8 @@ enum Commands {
     ///
     /// On Linux/macOS, the Bash shell profile will be modified to add $HOME/.local/bin to the PATH
     /// variable. On Windows, the user Path variable will be modified to add C:\Users\<username>\autonomi.
-    #[clap(verbatim_doc_comment)]
-    NodeManager {
+    #[clap(verbatim_doc_comment, name = "antctl")]
+    AntCtl {
         /// Override the default installation path.
         ///
         /// Any directories that don't exist will be created.
@@ -120,7 +120,7 @@ async fn main() -> Result<()> {
         }) => {
             println!("**************************************");
             println!("*                                    *");
-            println!("*        Installing autonomi         *");
+            println!("*          Installing ant            *");
             println!("*                                    *");
             println!("**************************************");
             install::check_prerequisites()?;
@@ -133,30 +133,24 @@ async fn main() -> Result<()> {
         }) => {
             println!("**************************************");
             println!("*                                    *");
-            println!("*          Installing safenode       *");
+            println!("*          Installing antnode        *");
             println!("*                                    *");
             println!("**************************************");
             install::check_prerequisites()?;
             process_install_cmd(AssetType::Node, path, version, no_modify_shell_profile).await
         }
-        Some(Commands::NodeManager {
+        Some(Commands::AntCtl {
             path,
             no_modify_shell_profile,
             version,
         }) => {
             println!("**************************************");
             println!("*                                    *");
-            println!("*    Installing safenode-manager     *");
+            println!("*         Installing antctl          *");
             println!("*                                    *");
             println!("**************************************");
             install::check_prerequisites()?;
-            process_install_cmd(
-                AssetType::NodeManager,
-                path,
-                version,
-                no_modify_shell_profile,
-            )
-            .await
+            process_install_cmd(AssetType::AntCtl, path, version, no_modify_shell_profile).await
         }
         Some(Commands::Update {}) => {
             println!("**************************************");

--- a/src/update.rs
+++ b/src/update.rs
@@ -51,39 +51,39 @@ mod test {
     #[test]
     fn perform_upgrade_assessment_should_indicate_no_previous_installation() -> Result<()> {
         let settings = Settings {
-            autonomi_path: None,
-            autonomi_version: None,
-            safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
-            safenode_version: Some(Version::new(0, 83, 13)),
-            safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
-            safenode_manager_version: Some(Version::new(0, 1, 8)),
+            ant_path: None,
+            ant_version: None,
+            antnode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
+            antnode_version: Some(Version::new(0, 83, 13)),
+            antctl_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
+            antctl_version: Some(Version::new(0, 1, 8)),
         };
         let decision =
             perform_update_assessment(&AssetType::Client, &Version::new(0, 78, 26), &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
 
         let settings = Settings {
-            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
-            autonomi_version: Some(Version::new(0, 78, 26)),
-            safenode_path: None,
-            safenode_version: None,
-            safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
-            safenode_manager_version: Some(Version::new(0, 1, 8)),
+            ant_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            ant_version: Some(Version::new(0, 78, 26)),
+            antnode_path: None,
+            antnode_version: None,
+            antctl_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
+            antctl_version: Some(Version::new(0, 1, 8)),
         };
         let decision =
             perform_update_assessment(&AssetType::Node, &Version::new(0, 83, 13), &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
 
         let settings = Settings {
-            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
-            autonomi_version: Some(Version::new(0, 78, 26)),
-            safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
-            safenode_version: Some(Version::new(0, 83, 13)),
-            safenode_manager_path: None,
-            safenode_manager_version: None,
+            ant_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            ant_version: Some(Version::new(0, 78, 26)),
+            antnode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
+            antnode_version: Some(Version::new(0, 83, 13)),
+            antctl_path: None,
+            antctl_version: None,
         };
         let decision =
-            perform_update_assessment(&AssetType::NodeManager, &Version::new(0, 1, 8), &settings)?;
+            perform_update_assessment(&AssetType::AntCtl, &Version::new(0, 1, 8), &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
 
         Ok(())
@@ -92,12 +92,12 @@ mod test {
     #[test]
     fn perform_upgrade_assessment_should_indicate_we_are_at_latest_version() -> Result<()> {
         let settings = Settings {
-            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
-            autonomi_version: Some(Version::new(0, 78, 26)),
-            safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
-            safenode_version: Some(Version::new(0, 83, 13)),
-            safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
-            safenode_manager_version: Some(Version::new(0, 1, 8)),
+            ant_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            ant_version: Some(Version::new(0, 78, 26)),
+            antnode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
+            antnode_version: Some(Version::new(0, 83, 13)),
+            antctl_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
+            antctl_version: Some(Version::new(0, 1, 8)),
         };
 
         let decision =
@@ -109,7 +109,7 @@ mod test {
         assert_matches!(decision, UpdateAssessmentResult::AtLatestVersion);
 
         let decision =
-            perform_update_assessment(&AssetType::NodeManager, &Version::new(0, 1, 8), &settings)?;
+            perform_update_assessment(&AssetType::AntCtl, &Version::new(0, 1, 8), &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::AtLatestVersion);
 
         Ok(())
@@ -119,12 +119,12 @@ mod test {
     fn perform_upgrade_assessment_latest_version_is_less_than_current_should_return_error(
     ) -> Result<()> {
         let settings = Settings {
-            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
-            autonomi_version: Some(Version::new(0, 78, 26)),
-            safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
-            safenode_version: Some(Version::new(0, 83, 13)),
-            safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
-            safenode_manager_version: Some(Version::new(0, 1, 8)),
+            ant_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            ant_version: Some(Version::new(0, 78, 26)),
+            antnode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
+            antnode_version: Some(Version::new(0, 83, 13)),
+            antctl_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
+            antctl_version: Some(Version::new(0, 1, 8)),
         };
 
         let result =
@@ -148,7 +148,7 @@ mod test {
         }
 
         let result =
-            perform_update_assessment(&AssetType::NodeManager, &Version::new(0, 1, 7), &settings);
+            perform_update_assessment(&AssetType::AntCtl, &Version::new(0, 1, 7), &settings);
         match result {
             Ok(_) => return Err(eyre!("this test should return an error")),
             Err(e) => assert_eq!(
@@ -164,12 +164,12 @@ mod test {
     fn perform_upgrade_assessment_should_perform_update_when_latest_patch_version_is_greater(
     ) -> Result<()> {
         let settings = Settings {
-            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
-            autonomi_version: Some(Version::new(0, 78, 26)),
-            safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
-            safenode_version: Some(Version::new(0, 83, 13)),
-            safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
-            safenode_manager_version: Some(Version::new(0, 1, 7)),
+            ant_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            ant_version: Some(Version::new(0, 78, 26)),
+            antnode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
+            antnode_version: Some(Version::new(0, 83, 13)),
+            antctl_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
+            antctl_version: Some(Version::new(0, 1, 7)),
         };
 
         let decision =
@@ -181,7 +181,7 @@ mod test {
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate(_));
 
         let decision =
-            perform_update_assessment(&AssetType::NodeManager, &Version::new(0, 1, 8), &settings)?;
+            perform_update_assessment(&AssetType::AntCtl, &Version::new(0, 1, 8), &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate(_));
 
         Ok(())
@@ -191,12 +191,12 @@ mod test {
     fn perform_upgrade_assessment_should_perform_update_when_latest_minor_version_is_greater(
     ) -> Result<()> {
         let settings = Settings {
-            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
-            autonomi_version: Some(Version::new(0, 78, 26)),
-            safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
-            safenode_version: Some(Version::new(0, 83, 13)),
-            safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
-            safenode_manager_version: Some(Version::new(0, 1, 7)),
+            ant_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            ant_version: Some(Version::new(0, 78, 26)),
+            antnode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
+            antnode_version: Some(Version::new(0, 83, 13)),
+            antctl_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
+            antctl_version: Some(Version::new(0, 1, 7)),
         };
 
         let decision =
@@ -208,7 +208,7 @@ mod test {
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate(_));
 
         let decision =
-            perform_update_assessment(&AssetType::NodeManager, &Version::new(0, 2, 0), &settings)?;
+            perform_update_assessment(&AssetType::AntCtl, &Version::new(0, 2, 0), &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate(_));
 
         Ok(())
@@ -218,12 +218,12 @@ mod test {
     fn perform_upgrade_assessment_should_perform_update_when_latest_major_version_is_greater(
     ) -> Result<()> {
         let settings = Settings {
-            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
-            autonomi_version: Some(Version::new(0, 78, 26)),
-            safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
-            safenode_version: Some(Version::new(0, 83, 13)),
-            safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
-            safenode_manager_version: Some(Version::new(0, 1, 7)),
+            ant_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            ant_version: Some(Version::new(0, 78, 26)),
+            antnode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
+            antnode_version: Some(Version::new(0, 83, 13)),
+            antctl_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
+            antctl_version: Some(Version::new(0, 1, 7)),
         };
 
         let decision =
@@ -235,7 +235,7 @@ mod test {
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate(_));
 
         let decision =
-            perform_update_assessment(&AssetType::NodeManager, &Version::new(1, 0, 0), &settings)?;
+            perform_update_assessment(&AssetType::AntCtl, &Version::new(1, 0, 0), &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate(_));
 
         Ok(())


### PR DESCRIPTION
This brings `safeup` in alignment with the rebranding of Safe Network to Autonomi.

BREAKING CHANGE:
* The crate name is changed from `safeup` -> `antup`.
* The binary name is changed from `safeup` -> `antup`.
* The new `ant-releases` repository is referenced and the `sn-releases` reference is removed.
* The settings file has its properties renamed.