### PR TITLE
chore: rebrand more references from safe -> ant

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,11 +117,11 @@ EOF
 
 function post_install() {
   if [[ $install_client -eq 1 ]]; then
-    echo "Now running antup to install the safe client..."
+    echo "Now running antup to install the ant client..."
     $target_dir/antup client
   fi
   if [[ $install_node -eq 1 ]]; then
-    echo "Now running antup to install safenode..."
+    echo "Now running antup to install antnode..."
     $target_dir/antup node
   fi
   if [[ $running_as_root -eq 1 ]]; then

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -72,7 +72,7 @@ pub(crate) async fn process_install_cmd(
 
 pub(crate) async fn process_update_cmd() -> Result<()> {
     let autonomi_config_dir_path = get_autonomi_config_dir_path()?;
-    let settings_file_path = autonomi_config_dir_path.join("safeup.json");
+    let settings_file_path = autonomi_config_dir_path.join("antup.json");
     let settings = Settings::read(&settings_file_path)?;
     let release_repo = <dyn AntReleaseRepoActions>::default_config();
 
@@ -116,7 +116,7 @@ pub(crate) async fn process_update_cmd() -> Result<()> {
 
 pub(crate) fn process_ls_command() -> Result<()> {
     let autonomi_config_dir_path = get_autonomi_config_dir_path()?;
-    let settings_file_path = autonomi_config_dir_path.join("safeup.json");
+    let settings_file_path = autonomi_config_dir_path.join("antup.json");
     let settings = Settings::read(&settings_file_path)?;
     let mut table = Table::new();
     table.add_row(Row::new(vec![
@@ -162,7 +162,7 @@ async fn do_install_binary(
     .await?;
 
     let autonomi_config_dir_path = get_autonomi_config_dir_path()?;
-    let settings_file_path = autonomi_config_dir_path.join("safeup.json");
+    let settings_file_path = autonomi_config_dir_path.join("antup.json");
     let mut settings = Settings::read(&settings_file_path)?;
     match asset_type {
         AssetType::Client => {
@@ -208,7 +208,7 @@ fn get_platform() -> Result<String> {
                 "We currently do not have binaries for the {OS}/{ARCH} combination"
             )),
         },
-        &_ => Err(eyre!("{OS} is not currently supported by safeup")),
+        &_ => Err(eyre!("{OS} is not currently supported by antup")),
     }
 }
 
@@ -243,7 +243,7 @@ fn get_shell_profile_path() -> Result<PathBuf> {
             match shell_bin_name.as_str() {
                 "bash" => ".bashrc",
                 "zsh" => ".zshrc",
-                _ => return Err(eyre!("shell {shell} is not supported by safeup")),
+                _ => return Err(eyre!("shell {shell} is not supported by antup")),
             }
         }
         Err(e) => return Err(eyre!(e)),

--- a/src/install.rs
+++ b/src/install.rs
@@ -73,9 +73,9 @@ impl AssetType {
 impl std::fmt::Display for AssetType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
-            AssetType::Client => write!(f, "autonomi"),
-            AssetType::Node => write!(f, "safenode"),
-            AssetType::AntCtl => write!(f, "safenode-manager"),
+            AssetType::Client => write!(f, "ant"),
+            AssetType::Node => write!(f, "antnode"),
+            AssetType::AntCtl => write!(f, "antctl"),
         }
     }
 }
@@ -264,7 +264,7 @@ pub fn check_prerequisites() -> Result<()> {
     )
 }
 
-/// Installs either the `safe` or `safenode` binary for the platform specified.
+/// Installs either the `ant` or `antnode` binary for the platform specified.
 ///
 /// The latest version is retrieved from Github, then the archive with the binary is downloaded
 /// from S3 and extracted to the specified location.
@@ -778,21 +778,21 @@ mod test {
     async fn save_should_write_new_settings_when_settings_file_does_not_exist() -> Result<()> {
         let tmp_data_path = assert_fs::TempDir::new()?;
         let settings_file = tmp_data_path.child("antup.json");
-        let safe_bin_file = tmp_data_path.child(ANT_BIN_NAME);
-        safe_bin_file.write_binary(b"fake safe code")?;
-        let safenode_bin_file = tmp_data_path.child("safenode");
-        safenode_bin_file.write_binary(b"fake safenode code")?;
-        let safenode_manager_bin_file = tmp_data_path.child("safenode-manager");
-        safenode_manager_bin_file.write_binary(b"fake safenode-manager code")?;
+        let ant_bin_file = tmp_data_path.child(ANT_BIN_NAME);
+        ant_bin_file.write_binary(b"fake safe code")?;
+        let antnode_bin_file = tmp_data_path.child("safenode");
+        antnode_bin_file.write_binary(b"fake safenode code")?;
+        let antctl_bin_file = tmp_data_path.child("safenode-manager");
+        antctl_bin_file.write_binary(b"fake safenode-manager code")?;
         let testnet_bin_file = tmp_data_path.child("testnet");
         testnet_bin_file.write_binary(b"fake testnet code")?;
 
         let settings = Settings {
-            ant_path: Some(safe_bin_file.to_path_buf()),
+            ant_path: Some(ant_bin_file.to_path_buf()),
             ant_version: Some(Version::new(0, 75, 1)),
-            antnode_path: Some(safenode_bin_file.to_path_buf()),
+            antnode_path: Some(antnode_bin_file.to_path_buf()),
             antnode_version: Some(Version::new(0, 75, 2)),
-            antctl_path: Some(safenode_manager_bin_file.to_path_buf()),
+            antctl_path: Some(antctl_bin_file.to_path_buf()),
             antctl_version: Some(Version::new(0, 1, 8)),
         };
 
@@ -800,14 +800,11 @@ mod test {
 
         settings_file.assert(predicates::path::is_file());
         let settings = Settings::read(&settings_file.to_path_buf())?;
-        assert_eq!(settings.ant_path, Some(safe_bin_file.to_path_buf()));
+        assert_eq!(settings.ant_path, Some(ant_bin_file.to_path_buf()));
         assert_eq!(settings.ant_version, Some(Version::new(0, 75, 1)));
-        assert_eq!(settings.antnode_path, Some(safenode_bin_file.to_path_buf()));
+        assert_eq!(settings.antnode_path, Some(antnode_bin_file.to_path_buf()));
         assert_eq!(settings.antnode_version, Some(Version::new(0, 75, 2)));
-        assert_eq!(
-            settings.antctl_path,
-            Some(safenode_manager_bin_file.to_path_buf())
-        );
+        assert_eq!(settings.antctl_path, Some(antctl_bin_file.to_path_buf()));
         assert_eq!(settings.antctl_version, Some(Version::new(0, 1, 8)));
         Ok(())
     }
@@ -821,21 +818,21 @@ mod test {
                 .join("dirs")
                 .join("antup.json"),
         );
-        let safe_bin_file = tmp_data_path.child(ANT_BIN_NAME);
-        safe_bin_file.write_binary(b"fake safe code")?;
-        let safenode_bin_file = tmp_data_path.child("safenode");
-        safenode_bin_file.write_binary(b"fake safenode code")?;
-        let safenode_manager_bin_file = tmp_data_path.child("safenode-manager");
-        safenode_manager_bin_file.write_binary(b"fake safenode-manager code")?;
+        let ant_bin_file = tmp_data_path.child(ANT_BIN_NAME);
+        ant_bin_file.write_binary(b"fake safe code")?;
+        let antnode_bin_file = tmp_data_path.child("safenode");
+        antnode_bin_file.write_binary(b"fake safenode code")?;
+        let antctl_bin_file = tmp_data_path.child("safenode-manager");
+        antctl_bin_file.write_binary(b"fake safenode-manager code")?;
         let testnet_bin_file = tmp_data_path.child("testnet");
         testnet_bin_file.write_binary(b"fake testnet code")?;
 
         let settings = Settings {
-            ant_path: Some(safe_bin_file.to_path_buf()),
+            ant_path: Some(ant_bin_file.to_path_buf()),
             ant_version: Some(Version::new(0, 75, 1)),
-            antnode_path: Some(safenode_bin_file.to_path_buf()),
+            antnode_path: Some(antnode_bin_file.to_path_buf()),
             antnode_version: Some(Version::new(0, 75, 2)),
-            antctl_path: Some(safenode_manager_bin_file.to_path_buf()),
+            antctl_path: Some(antctl_bin_file.to_path_buf()),
             antctl_version: Some(Version::new(0, 1, 8)),
         };
 
@@ -843,14 +840,11 @@ mod test {
 
         settings_file.assert(predicates::path::is_file());
         let settings = Settings::read(&settings_file.to_path_buf())?;
-        assert_eq!(settings.ant_path, Some(safe_bin_file.to_path_buf()));
+        assert_eq!(settings.ant_path, Some(ant_bin_file.to_path_buf()));
         assert_eq!(settings.ant_version, Some(Version::new(0, 75, 1)));
-        assert_eq!(settings.antnode_path, Some(safenode_bin_file.to_path_buf()));
+        assert_eq!(settings.antnode_path, Some(antnode_bin_file.to_path_buf()));
         assert_eq!(settings.antnode_version, Some(Version::new(0, 75, 2)));
-        assert_eq!(
-            settings.antctl_path,
-            Some(safenode_manager_bin_file.to_path_buf())
-        );
+        assert_eq!(settings.antctl_path, Some(antctl_bin_file.to_path_buf()));
         assert_eq!(settings.antctl_version, Some(Version::new(0, 1, 8)));
         Ok(())
     }

--- a/src/update.rs
+++ b/src/update.rs
@@ -32,7 +32,7 @@ pub fn perform_update_assessment(
                 return Err(eyre!(
                     "The latest version is less than the current version of your binary."
                 )
-                .suggestion("You may want to remove your safeup.conf and install safeup again."))
+                .suggestion("You may want to remove your antup.json and install antup again."))
             }
             Ordering::Greater => return Ok(UpdateAssessmentResult::PerformUpdate(installed_path)),
         }


### PR DESCRIPTION
Replaces old text output from, e.g., `safenode-manager` to `antctl`. Users had reported this.

BREAKING CHANGE: the config file was changed from `safeup.json` to `antup.json`.